### PR TITLE
Simplify Docker instructions

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -51,7 +51,6 @@ MODEL=meta-llama/Meta-Llama-3.1-8B-Instruct
 Deploy the inference backend with a `vllm` Docker container.
 ```bash
 docker run \
-     --runtime nvidia \
      --gpus all \
      -v ~/.cache/huggingface:/root/.cache/huggingface \
      -p 8000:8000 \

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -19,10 +19,10 @@ We use the FP8 quantized 405B models for this guide as the non quantized 405B mo
 
 ## Serving guide
 
-1. [Setup Docker and NVIDIA Container Toolkit](#setup-docker-and-nvidia-container-toolkit)
+1. [Setup Docker](#setup-docker)
 2. [Serve the model](#serve-the-model)
 
-### Setup Docker and NVIDIA Container Toolkit
+### Setup Docker
 
 *The rest of this guide assumes that your environment has Docker and NVIDIA Container Toolkit installed, as is the case for Lambda Cloud instances. Please refer to the [Docker guide](https://docs.docker.com/engine/install/ubuntu/) and to the [NVIDIA guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) if you are not using Lambda Cloud and need to install these requirements.*
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -26,12 +26,6 @@ We use the FP8 quantized 405B models for this guide as the non quantized 405B mo
 
 *The rest of this guide assumes that your environment has Docker and NVIDIA Container Toolkit installed, as is the case for Lambda Cloud instances. Please refer to the [Docker guide](https://docs.docker.com/engine/install/ubuntu/) and to the [NVIDIA guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) if you are not using Lambda Cloud and need to install these requirements.*
 
-Configure NVIDIA Container Toolkit
-```bash
-sudo nvidia-ctk runtime configure --runtime=docker
-sudo systemctl restart docker
-```
-
 Add Current User to Docker Group
 ```bash
 sudo usermod -aG docker $USER


### PR DESCRIPTION
It's unneeded to configure NVIDIA Container Toolkit and specify to use the nvidia runtime.